### PR TITLE
feat: audit module

### DIFF
--- a/live/ci/audit/terragrunt.hcl
+++ b/live/ci/audit/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../modules//audit"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}

--- a/live/dev/audit/terragrunt.hcl
+++ b/live/dev/audit/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../modules//audit"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}

--- a/live/prod/audit/terragrunt.hcl
+++ b/live/prod/audit/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../modules//audit"
+}
+
+include "root" {
+  path = find_in_parent_folders()
+}

--- a/modules/audit/main.tf
+++ b/modules/audit/main.tf
@@ -1,0 +1,122 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "4.55.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = merge(var.tags, { User = var.user })
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_role" "AWSServiceRoleForCloudTrail" {
+  name = "AWSServiceRoleForCloudTrail"
+}
+
+resource "aws_cloudtrail" "cloudtrail" {
+  name                       = "pe-tf-audit"
+  s3_bucket_name             = aws_s3_bucket.s3_bucket.id
+  is_multi_region_trail      = true
+  cloud_watch_logs_group_arn = "${aws_cloudwatch_log_group.cloudwatch_log_group.arn}:*"
+  cloud_watch_logs_role_arn  = data.aws_iam_role.AWSServiceRoleForCloudTrail.arn
+
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3"]
+    }
+  }
+}
+
+resource "aws_s3_bucket" "s3_bucket" {
+  bucket        = "pe-tf-audit"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket_policy" "s3_bucket_policy" {
+  bucket = aws_s3_bucket.s3_bucket.id
+  policy = <<POLICY
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSCloudTrailAclCheck",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "${aws_s3_bucket.s3_bucket.arn}"
+        },
+        {
+            "Sid": "AWSCloudTrailWrite",
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "cloudtrail.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "${aws_s3_bucket.s3_bucket.arn}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                }
+            }
+        }
+    ]
+}
+POLICY
+}
+
+resource "aws_cloudwatch_log_group" "cloudwatch_log_group" {
+  name = "pe-tf-audit"
+}
+
+resource "aws_cloudwatch_log_metric_filter" "cloudwatch_log_metric_filter" {
+  name           = "APICallsWithAccessKeys"
+  pattern        = "{ $.userIdentity.type = \"IAMUser\" }"
+  log_group_name = aws_cloudwatch_log_group.cloudwatch_log_group.name
+  metric_transformation {
+    name          = "COUNT(Calls with Access Keys)"
+    namespace     = "PE/Audit"
+    value         = "1"
+    default_value = "0"
+    unit          = "Count"
+  }
+}
+
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "pe-tf-audit"
+
+  dashboard_body = <<EOF
+{
+  "widgets": [
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 0,
+      "width": 6,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "metrics": [
+          [ "PE/Audit", "COUNT(Calls with Access Keys)" ]
+        ],
+        "region": "eu-west-2",
+        "stat": "SampleCount"
+      }
+    }
+  ]
+}
+EOF
+}

--- a/modules/audit/variable.tf
+++ b/modules/audit/variable.tf
@@ -1,0 +1,14 @@
+variable "aws_region" {
+  type    = string
+  default = "eu-west-2"
+}
+variable "user" {
+  type    = string
+  default = ""
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = { "Project" = "Project Engineering" }
+  description = "Resource tags"
+}


### PR DESCRIPTION
audit service which collects the api calls executed in one AWS account, across multi regions, with AWS access keys.
The number of calls is collected and displayed in a cloudwatch dashboard.
https://eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#dashboards:name=pe-tf-audit